### PR TITLE
Adjust test to expect KNIME v3.7+ behavior in its json parser.

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -244,34 +244,24 @@ class CoreFunctionsTest(unittest.TestCase):
             "table-spec": [{"column-int": "int"}, {"b": "string"}],
             "table-data": [["boil", 98.7], ["freeze", False]]
         }
-        results = self.templated_test_container_1_input_1_output(
-            input_data_table=mismatched_types_input_data_table_dict_1,
-            output_as_pandas_dataframes=False,
-        )
-        self.assertEqual(len(results), 1)
-        self.assertEqual(len(results[0]["table-data"]), 2)
-        self.assertEqual(len(results[0]["table-data"][0]), 3)
-        self.assertEqual(
-            results[0]["table-data"],
-            [[None, "98.7", None], [None, "false", None]]
-        )
+        with self.assertLogs(level=logging.ERROR):
+            with self.assertRaises(ChildProcessError):
+                results = self.templated_test_container_1_input_1_output(
+                    input_data_table=mismatched_types_input_data_table_dict_1,
+                    output_as_pandas_dataframes=False,
+                )
 
         # Float in column meant for int also results in missing values.
         mismatched_types_input_data_table_dict_2 = {
             "table-spec": [{"column-int": "int"}, {"b": "string"}],
             "table-data": [[100.567, "boil"], [0.123, "freeze"]]
         }
-        results = self.templated_test_container_1_input_1_output(
-            input_data_table=mismatched_types_input_data_table_dict_2,
-            output_as_pandas_dataframes=False,
-        )
-        self.assertEqual(len(results), 1)
-        self.assertEqual(len(results[0]["table-data"]), 2)
-        self.assertEqual(len(results[0]["table-data"][0]), 3)
-        self.assertEqual(
-            results[0]["table-data"],
-            [[None, "boil", None], [None, "freeze", None]]
-        )
+        with self.assertLogs(level=logging.ERROR):
+            with self.assertRaises(ChildProcessError):
+                results = self.templated_test_container_1_input_1_output(
+                    input_data_table=mismatched_types_input_data_table_dict_2,
+                    output_as_pandas_dataframes=False,
+                )
 
 
     def test_non_existent_workflow_execution(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -245,11 +245,16 @@ class CoreFunctionsTest(unittest.TestCase):
             "table-data": [["boil", 98.7], ["freeze", False]]
         }
         with self.assertLogs(level=logging.ERROR):
-            with self.assertRaises(ChildProcessError):
+            with self.assertRaises(ChildProcessError) as cm:
                 results = self.templated_test_container_1_input_1_output(
                     input_data_table=mismatched_types_input_data_table_dict_1,
                     output_as_pandas_dataframes=False,
                 )
+            # Verify this was not a consequence of a locked workflow conflict.
+            self.assertNotEqual(
+                cm.exception.args[0],
+                knime.KEYPHRASE_LOCKED.decode('utf8')
+            )
 
         # Float in column meant for int also results in missing values.
         mismatched_types_input_data_table_dict_2 = {
@@ -257,11 +262,17 @@ class CoreFunctionsTest(unittest.TestCase):
             "table-data": [[100.567, "boil"], [0.123, "freeze"]]
         }
         with self.assertLogs(level=logging.ERROR):
-            with self.assertRaises(ChildProcessError):
+            with self.assertRaises(ChildProcessError) as cm:
                 results = self.templated_test_container_1_input_1_output(
                     input_data_table=mismatched_types_input_data_table_dict_2,
                     output_as_pandas_dataframes=False,
                 )
+            # Verify this was not a consequence of a locked workflow conflict.
+            self.assertNotEqual(
+                cm.exception.args[0],
+                knime.KEYPHRASE_LOCKED.decode('utf8')
+            )
+
 
 
     def test_non_existent_workflow_execution(self):


### PR DESCRIPTION
Per issue #10 this patch adjusts the test, which was originally created to document KNIME v3.6 behavior, to henceforth expect KNIME v3.7 behavior in its Container Input (Table) node's json parser.

To be clear, this does not break any support for KNIME v3.6 but this test will no longer pass with versions of KNIME older than v3.7.