### PR TITLE
Implements a warning if input is not set (set to None)

### DIFF
--- a/knime.py
+++ b/knime.py
@@ -29,9 +29,9 @@ import os
 
 
 __author__ = "Appliomics, LLC"
-__copyright__ = "Copyright 2018-2019, KNIME AG"
+__copyright__ = "Copyright 2018-2020, KNIME AG"
 __credits__ = [ "Davin Potts", "Greg Landrum" ]
-__version__ = "0.9.6"
+__version__ = "0.10.0"
 
 
 __all__ = [ "Workflow", "LocalWorkflow", "RemoteWorkflow", "executable_path" ]
@@ -40,7 +40,7 @@ __all__ = [ "Workflow", "LocalWorkflow", "RemoteWorkflow", "executable_path" ]
 if os.name == "nt":
     executable_path = os.getenv("KNIME_EXEC", r"C:\Program Files\KNIME\knime.exe")
 else:
-    executable_path = os.getenv("KNIME_EXEC", "/opt/local/knime_4.0.0/knime")
+    executable_path = os.getenv("KNIME_EXEC", "/opt/local/knime_4.2.0/knime")
 
 
 KEYPHRASE_LOCKED = b"Workflow is locked by another KNIME instance"

--- a/knime.py
+++ b/knime.py
@@ -211,6 +211,10 @@ def run_workflow_using_multiple_service_tables(
 
         option_flags_input_service_table_nodes = []
         for node_id, data in zip(input_service_table_node_ids, input_datas):
+            if data is None:
+                raise Warning(f'No input set for node_id={node_id}')
+                continue
+
             input_json_filename = input_json_filename_pattern % node_id
             input_json_filepath = Path(temp_dir, input_json_filename)
 

--- a/knime.py
+++ b/knime.py
@@ -23,6 +23,7 @@ from pathlib import Path, PurePosixPath
 import tempfile
 import subprocess
 import shlex
+import warnings
 import logging
 import os
 
@@ -212,7 +213,7 @@ def run_workflow_using_multiple_service_tables(
         option_flags_input_service_table_nodes = []
         for node_id, data in zip(input_service_table_node_ids, input_datas):
             if data is None:
-                raise Warning(f'No input set for node_id={node_id}')
+                warnings.warn(f'No input set for node_id={node_id}', UserWarning)
                 continue
 
             input_json_filename = input_json_filename_pattern % node_id

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ if __name__ == "__main__":
             "Intended Audience :: End Users/Desktop",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
             "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         ],
         project_urls={

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -97,6 +97,7 @@ class CoreFunctionsTest(unittest.TestCase):
         )
         t.join()
 
+
     def test_container_1_input_1_output_dict_input_with_pandas(self):
         if pd is None:
             self.skipTest("pandas not available")
@@ -300,7 +301,6 @@ class CoreFunctionsTest(unittest.TestCase):
                 cm.exception.args[0],
                 knime.KEYPHRASE_LOCKED.decode('utf8')
             )
-
 
 
     def test_non_existent_workflow_execution(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,6 +6,7 @@ import sys
 import threading
 import time
 import unittest
+import warnings
 try:
     import pandas as pd
     import numpy as np
@@ -163,9 +164,10 @@ class CoreFunctionsTest(unittest.TestCase):
 
 
     def test_container_1_input_1_output_no_input_data_without_pandas(self):
-        results = self.templated_test_container_1_input_1_output(
-            output_as_pandas_dataframes=False,
-        )
+        with self.assertWarns(UserWarning):
+            results = self.templated_test_container_1_input_1_output(
+                output_as_pandas_dataframes=False,
+            )
         self.assertEqual(len(results), 1)
         self.assertTrue(isinstance(results[0], dict))
         returned_table_spec = (list(d)[0] for d in results[0]["table-spec"])
@@ -176,9 +178,10 @@ class CoreFunctionsTest(unittest.TestCase):
 
 
     def test_container_1_input_1_output_no_input_data(self):
-        results = self.templated_test_container_1_input_1_output(
-            output_as_pandas_dataframes=None,
-        )
+        with self.assertWarns(UserWarning):
+            results = self.templated_test_container_1_input_1_output(
+                output_as_pandas_dataframes=None,
+            )
         self.assertEqual(len(results), 1)
         if pd is not None:
             self.assertTrue(isinstance(results[0], pd.DataFrame))
@@ -189,9 +192,10 @@ class CoreFunctionsTest(unittest.TestCase):
     def test_container_1_input_1_output_no_input_data_with_pandas(self):
         if pd is None:
             self.skipTest("pandas not available")
-        results = self.templated_test_container_1_input_1_output(
-            output_as_pandas_dataframes=True,
-        )
+        with self.assertWarns(UserWarning):
+            results = self.templated_test_container_1_input_1_output(
+                output_as_pandas_dataframes=True,
+            )
         self.assertEqual(len(results), 1)
         df = results[0]
         self.assertTrue(isinstance(df, pd.DataFrame))
@@ -309,7 +313,8 @@ class CoreFunctionsTest(unittest.TestCase):
                 workflow_path="never_gonna_let_you_down"
             ) as wf:
                 # Existence of workflow is only checked in execute().
-                wf.execute(output_as_pandas_dataframes=False)
+                with self.assertWarns(UserWarning):
+                    wf.execute(output_as_pandas_dataframes=False)
                 results = wf.data_table_outputs[:]
 
 
@@ -318,7 +323,8 @@ class CoreFunctionsTest(unittest.TestCase):
             workspace_path="tests/knime-workspace",
             workflow_path="test_simple_container_table_01"
         ) as wf:
-            wf.execute(output_as_pandas_dataframes=False)
+            with self.assertWarns(UserWarning):
+                wf.execute(output_as_pandas_dataframes=False)
             results = wf.data_table_outputs[:]
         self.assertEqual(len(results), 1)
 
@@ -326,7 +332,8 @@ class CoreFunctionsTest(unittest.TestCase):
             workspace_path="tests/knime-workspace",
             workflow_path="/test_simple_container_table_01"
         ) as wf:
-            wf.execute(output_as_pandas_dataframes=False)
+            with self.assertWarns(UserWarning):
+                wf.execute(output_as_pandas_dataframes=False)
             results = wf.data_table_outputs[:]
         self.assertEqual(len(results), 1)
 
@@ -336,7 +343,8 @@ class CoreFunctionsTest(unittest.TestCase):
                 workspace_path="tests/knime-workspace",
                 workflow_path="never_gonna_run_around_and_desert_you"
             ) as wf:
-                wf.execute(output_as_pandas_dataframes=False)
+                with self.assertWarns(UserWarning):
+                    wf.execute(output_as_pandas_dataframes=False)
                 results = wf.data_table_outputs[:]
 
         with self.assertRaises(FileNotFoundError):
@@ -345,13 +353,15 @@ class CoreFunctionsTest(unittest.TestCase):
                 workspace_path="/tests/knime-workspace",
                 workflow_path="/test_simple_container_table_01"
             ) as wf:
-                wf.execute(output_as_pandas_dataframes=False)
+                with self.assertWarns(UserWarning):
+                    wf.execute(output_as_pandas_dataframes=False)
                 results = wf.data_table_outputs[:]
 
 
     def test_AAAA_nosave_workflow_after_execution_as_default(self):
         with knime.Workflow("tests/knime-workspace/test_simple_container_table_01") as wf:
-            wf.execute(output_as_pandas_dataframes=False)
+            with self.assertWarns(UserWarning):
+                wf.execute(output_as_pandas_dataframes=False)
             results = wf.data_table_outputs[:]
             self.assertEqual(wf.data_table_inputs_parameter_names, ("input",))
 
@@ -363,7 +373,8 @@ class CoreFunctionsTest(unittest.TestCase):
     def test_zzzz_save_workflow_after_execution(self):
         with knime.Workflow("tests/knime-workspace/test_simple_container_table_01") as wf:
             wf.save_after_execution = True
-            wf.execute(output_as_pandas_dataframes=False)
+            with self.assertWarns(UserWarning):
+                wf.execute(output_as_pandas_dataframes=False)
             results = wf.data_table_outputs[:]
             self.assertEqual(wf.data_table_inputs_parameter_names, ("input",))
 


### PR DESCRIPTION
This implements the changes called for in issue #24 with added relevant tests.

It is hoped that this will benefit users who mistakenly forget to set one or more inputs (for corresponding Container Input nodes in a KNIME Workflow), saving them valuable time.  Implemented with functionality from the Python standard library's `warnings` module, it should also be easily suppressed in situations where not supplying an input data table is desired.
